### PR TITLE
updates for purescript-0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: node_js
 node_js:
   - "stable"
 before_install:
-  - npm install -g bower pulp purescript
-  - bower install
+  - npm install -g bower pulp purescript spago
+  - purs --version
+  - spago --version
 script:
-  - npm test
+  - spago test
   - npm run-script example
 sudo: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-server-sent-events",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A purescript interface to the Server-Sent Events API (SSE).",
   "main": "server.js",
   "directories": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,4 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210409/packages.dhall sha256:e81c2f2ce790c0e0d79869d22f7a37d16caeb5bd81cfda71d46c58f6199fd33f
+
+in  upstream

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,13 +1,12 @@
 {
     "name": "purescript-server-sent-events",
-    "set": "psc-0.12.0",
+    "set": "psc-0.14.0",
     "source": "https://github.com/purescript/package-sets.git",
     "depends": [
         "console",
         "effect",
         "functions",
-        "generics-rep",
-	"maybe",
+        "maybe",
         "prelude",
         "web-events"
     ]

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,13 @@
+{ name = "purescript-server-sent-events"
+, dependencies =
+  [ "console"
+  , "effect"
+  , "functions"
+  , "maybe"
+  , "prelude"
+  , "psci-support"
+  , "web-events"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs" ]
+}

--- a/src/Network/EventSource.purs
+++ b/src/Network/EventSource.purs
@@ -27,7 +27,7 @@ module Network.EventSource
 import Effect
 import Data.Function.Uncurried (runFn2, runFn1, Fn2, Fn1)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Data.Maybe (Maybe(Just, Nothing))
 import Prelude (class Eq, class Show, Unit, bind, pure, (=<<))
 import Web.Event.Event (Event, EventType)


### PR DESCRIPTION
As the title says, updates to make this compile under purescript-0.14.

Once this is accepted I can make a PR to [re-enable this package under package-sets](https://github.com/purescript/package-sets/blob/master/src/groups/michaelxavier.dhall) (unless you'd like to do that yourself).

Motivation: I have a project that uses this package and I want to update to ps-0.14.